### PR TITLE
chore: get members & timers offset now uses identifiers as start pos

### DIFF
--- a/adapters/repositories-integration/src/main/kotlin/org/tomadoro/backend/repositories/integration/TimersRepository.kt
+++ b/adapters/repositories-integration/src/main/kotlin/org/tomadoro/backend/repositories/integration/TimersRepository.kt
@@ -1,5 +1,6 @@
 package org.tomadoro.backend.repositories.integration
 
+import org.tomadoro.backend.domain.Count
 import org.tomadoro.backend.domain.DateTime
 import org.tomadoro.backend.domain.Milliseconds
 import org.tomadoro.backend.domain.TimerName
@@ -49,9 +50,10 @@ class TimersRepository(
 
     override suspend fun getMembers(
         timerId: TimersRepository.TimerId,
-        boundaries: IntProgression
+        fromUser: UsersRepository.UserId?,
+        count: Count
     ): Sequence<UsersRepository.UserId> {
-        return datasource.getMembersIds(timerId.int, boundaries)
+        return datasource.getMembersIds(timerId.int, fromUser?.int ?: 0, count.int)
             .map { UsersRepository.UserId(it) }
     }
 
@@ -61,9 +63,10 @@ class TimersRepository(
 
     override suspend fun getTimers(
         userId: UsersRepository.UserId,
-        boundaries: IntProgression
+        fromTimer: TimersRepository.TimerId?,
+        count: Count
     ): Sequence<TimersRepository.Timer> {
-        return datasource.getUserTimers(userId.int, boundaries).map { it.toExternalTimer() }
+        return datasource.getUserTimers(userId.int, fromTimer?.int ?: 0, count.int).map { it.toExternalTimer() }
     }
 
     private fun TimersDatabaseDataSource.Timer.toExternalTimer(): TimersRepositoryContract.Timer {

--- a/adapters/repositories-integration/src/test/kotlin/org/tomadoro/backend/repositories/integration/test/TimersRepositoryTest.kt
+++ b/adapters/repositories-integration/src/test/kotlin/org/tomadoro/backend/repositories/integration/test/TimersRepositoryTest.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.junit.platform.commons.annotation.Testable
+import org.tomadoro.backend.domain.Count
 import org.tomadoro.backend.domain.DateTime
 import org.tomadoro.backend.domain.TimerName
 import org.tomadoro.backend.repositories.UsersRepository
@@ -51,7 +52,7 @@ class TimersRepositoryTest {
 
         timers.removeTimer(id)
         assert(timers.getTimer(id) == null)
-        assert(timers.getMembers(id, 0..1).none())
+        assert(timers.getMembers(id, null, Count(1)).none())
         assert(timers.getTimerSettings(id) == null)
     }
 
@@ -72,6 +73,6 @@ class TimersRepositoryTest {
         )
 
 
-        assert(!timers.getTimers(UsersRepository.UserId(1), 0..2).none())
+        assert(!timers.getTimers(UsersRepository.UserId(1), null, Count(2)).none())
     }
 }

--- a/application/src/main/kotlin/org/tomadoro/backend/application/routes/timer/getTimers.kt
+++ b/application/src/main/kotlin/org/tomadoro/backend/application/routes/timer/getTimers.kt
@@ -7,18 +7,21 @@ import io.ktor.server.util.*
 import org.tomadoro.backend.application.plugins.authorized
 import org.tomadoro.backend.application.results.GetTimersResult
 import org.tomadoro.backend.application.types.serializable
+import org.tomadoro.backend.domain.Count
+import org.tomadoro.backend.repositories.TimersRepository
 import org.tomadoro.backend.usecases.timers.GetTimersUseCase
 
 fun Route.getTimers(getTimers: GetTimersUseCase) {
     get("all") {
         authorized { userId ->
             val count = call.request.queryParameters.getOrFail("count").toInt()
-            val offset = call.request.queryParameters.getOrFail("offset").toInt()
+            val fromId = call.request.queryParameters["from_id"]?.toInt()
             val result: GetTimersResult =
                 GetTimersResult.Success(
                     (getTimers(
                         userId,
-                        offset..count + offset
+                        fromId?.let { it1 -> TimersRepository.TimerId(it1) },
+                        Count(count)
                     ) as GetTimersUseCase.Result.Success).list.map { it.serializable() }
                 )
 

--- a/application/src/main/kotlin/org/tomadoro/backend/application/types/Timer.kt
+++ b/application/src/main/kotlin/org/tomadoro/backend/application/types/Timer.kt
@@ -12,7 +12,8 @@ import org.tomadoro.backend.repositories.TimersRepository
 class Timer(
     @SerialName("timer_id") val timerId: TimerId,
     val name: Name,
-    @SerialName("owner_id") val ownerId: UserId,
+    @SerialName("owner_id")
+    val ownerId: UserId,
     val settings: TimerSettings
 )
 

--- a/domain/src/main/kotlin/org/tomadoro/backend/domain/Count.kt
+++ b/domain/src/main/kotlin/org/tomadoro/backend/domain/Count.kt
@@ -1,0 +1,8 @@
+package org.tomadoro.backend.domain
+
+@JvmInline
+value class Count(val int: Int) {
+    companion object {
+        val MAX = Count(Int.MAX_VALUE)
+    }
+}

--- a/use-cases/src/main/kotlin/org/tomadoro/backend/repositories/TimersRepository.kt
+++ b/use-cases/src/main/kotlin/org/tomadoro/backend/repositories/TimersRepository.kt
@@ -1,5 +1,6 @@
 package org.tomadoro.backend.repositories
 
+import org.tomadoro.backend.domain.Count
 import org.tomadoro.backend.domain.DateTime
 import org.tomadoro.backend.domain.Milliseconds
 import org.tomadoro.backend.domain.TimerName
@@ -18,13 +19,21 @@ interface TimersRepository {
     suspend fun getTimerSettings(timerId: TimerId): Settings?
     suspend fun setTimerSettings(timerId: TimerId, settings: NewSettings)
     suspend fun addMember(userId: UsersRepository.UserId, timerId: TimerId)
-    suspend fun getMembers(timerId: TimerId, boundaries: IntProgression): Sequence<UsersRepository.UserId>
+    suspend fun getMembers(
+        timerId: TimerId,
+        fromUser: UsersRepository.UserId?,
+        count: Count
+    ): Sequence<UsersRepository.UserId>
     suspend fun isMemberOf(userId: UsersRepository.UserId, timerId: TimerId): Boolean
 
     /**
      * Gets all timers where [userId] is participating.
      */
-    suspend fun getTimers(userId: UsersRepository.UserId, boundaries: IntProgression): Sequence<Timer>
+    suspend fun getTimers(
+        userId: UsersRepository.UserId,
+        fromTimer: TimerId?,
+        count: Count
+    ): Sequence<Timer>
 
     data class Settings(
         val workTime: Milliseconds,

--- a/use-cases/src/main/kotlin/org/tomadoro/backend/usecases/timers/GetTimersUseCase.kt
+++ b/use-cases/src/main/kotlin/org/tomadoro/backend/usecases/timers/GetTimersUseCase.kt
@@ -1,5 +1,6 @@
 package org.tomadoro.backend.usecases.timers
 
+import org.tomadoro.backend.domain.Count
 import org.tomadoro.backend.repositories.TimersRepository
 import org.tomadoro.backend.repositories.UsersRepository
 
@@ -7,9 +8,11 @@ class GetTimersUseCase(
     private val timers: TimersRepository
 ) {
     suspend operator fun invoke(
-        userId: UsersRepository.UserId, boundaries: IntProgression
+        userId: UsersRepository.UserId,
+        fromId: TimersRepository.TimerId?,
+        count: Count
     ): Result {
-        return Result.Success(timers.getTimers(userId, boundaries).toList())
+        return Result.Success(timers.getTimers(userId, fromId, count).toList())
     }
 
     sealed interface Result {

--- a/use-cases/src/test/kotlin/org/tomadoro/backend/repositories/MockedTimersRepository.kt
+++ b/use-cases/src/test/kotlin/org/tomadoro/backend/repositories/MockedTimersRepository.kt
@@ -1,5 +1,6 @@
 package org.tomadoro.backend.repositories
 
+import org.tomadoro.backend.domain.Count
 import org.tomadoro.backend.domain.DateTime
 import org.tomadoro.backend.domain.TimerName
 
@@ -64,7 +65,8 @@ class MockedTimersRepository : TimersRepository {
 
     override suspend fun getMembers(
         timerId: TimersRepository.TimerId,
-        boundaries: IntProgression
+        fromUser: UsersRepository.UserId?,
+        count: Count
     ): Sequence<UsersRepository.UserId> {
         return (timers.getOrNull(timerId.int)?.members ?: emptyList()).asSequence()
     }
@@ -75,7 +77,8 @@ class MockedTimersRepository : TimersRepository {
 
     override suspend fun getTimers(
         userId: UsersRepository.UserId,
-        boundaries: IntProgression
+        fromTimer: TimersRepository.TimerId?,
+        count: Count
     ): Sequence<TimersRepository.Timer> {
         return timers.asSequence().filter { it.members.contains(userId) }
             .mapIndexed { i, e -> e.toOriginal(TimersRepository.TimerId(i)) }

--- a/use-cases/src/test/kotlin/org/tomadoro/backend/usecases/timers/GetTimersUseCaseTest.kt
+++ b/use-cases/src/test/kotlin/org/tomadoro/backend/usecases/timers/GetTimersUseCaseTest.kt
@@ -2,6 +2,7 @@ package org.tomadoro.backend.usecases.timers
 
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import org.tomadoro.backend.domain.Count
 import org.tomadoro.backend.domain.TimerName
 import org.tomadoro.backend.providers.MockedCurrentTimeProvider
 import org.tomadoro.backend.repositories.MockedTimersRepository
@@ -31,7 +32,7 @@ class GetTimersUseCaseTest {
 
     @Test
     fun testSuccess() = runBlocking {
-        val result = useCase(UsersRepository.UserId(0), 0..Int.MAX_VALUE)
+        val result = useCase(UsersRepository.UserId(0), null, Count.MAX)
         assert(result is GetTimersUseCase.Result.Success)
         result as GetTimersUseCase.Result.Success
         assert(result.list.size == 1)


### PR DESCRIPTION
Signed-off-by: Vadim Yaroschuk <y9vad9@gmail.com>

**Is it breaking change?**

Yes, it breaks functionality from SDK where it uses item index as offset.

**Have you synchronized changes with other repositories?**

Not yet.

**Explain why this change is important**

Look #3 

**Specify linked issues or discussions**

close #3
